### PR TITLE
`LogLevel.ALL`을 제거합니다.

### DIFF
--- a/src/main/java/letsdev/common/log/LevelFixedLogger.java
+++ b/src/main/java/letsdev/common/log/LevelFixedLogger.java
@@ -13,14 +13,14 @@ public final class LevelFixedLogger {
     private final BiConsumer<String, Object[]> logBiConsumer;
 
     public LevelFixedLogger(Logger logger, LogLevel logLevel) {
-        assert LogLevel.values().length == 7 : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
+        // FIXME don't rely on the size.
+        assert LogLevel.values().length == 6 : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
         Objects.requireNonNull(logger);
         Objects.requireNonNull(logLevel);
 
         this.logLevel = logLevel;
 
         switch (logLevel) {
-            case ALL:
             case TRACE:
                 logConsumer = logger::trace;
                 logBiConsumer = logger::trace;

--- a/src/main/java/letsdev/common/log/LevelFixedLogger.java
+++ b/src/main/java/letsdev/common/log/LevelFixedLogger.java
@@ -3,6 +3,7 @@ package letsdev.common.log;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -13,6 +14,21 @@ public final class LevelFixedLogger {
     private final BiConsumer<String, Object[]> logBiConsumer;
 
     public LevelFixedLogger(Logger logger, LogLevel logLevel) {
+        /* NOTE DO NOT USE `Set.of`.
+         *  Because `Set.of` is not compatible with JDK 1.8
+         *  See:
+         *      Set.of          since 9
+         *      EnumSet.of      since 1.5
+         *      EnumSet.allOf   since 1.5
+         */
+        assert EnumSet.of(
+                LogLevel.TRACE,
+                LogLevel.DEBUG,
+                LogLevel.INFO,
+                LogLevel.WARN,
+                LogLevel.ERROR,
+                LogLevel.OFF
+        ).equals(EnumSet.allOf(LogLevel.class)) : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
         // FIXME don't rely on the size.
         assert LogLevel.values().length == 6 : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
         Objects.requireNonNull(logger);

--- a/src/main/java/letsdev/common/log/LevelFixedLogger.java
+++ b/src/main/java/letsdev/common/log/LevelFixedLogger.java
@@ -29,8 +29,6 @@ public final class LevelFixedLogger {
                 LogLevel.ERROR,
                 LogLevel.OFF
         ).equals(EnumSet.allOf(LogLevel.class)) : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
-        // FIXME don't rely on the size.
-        assert LogLevel.values().length == 6 : "추가된 로그 레벨에 대한 적절한 조치가 필요합니다.";
         Objects.requireNonNull(logger);
         Objects.requireNonNull(logLevel);
 

--- a/src/main/java/letsdev/common/log/LogLevel.java
+++ b/src/main/java/letsdev/common/log/LogLevel.java
@@ -1,7 +1,6 @@
 package letsdev.common.log;
 
 public enum LogLevel {
-    ALL,
     TRACE,
     DEBUG,
     INFO,


### PR DESCRIPTION
# Pull Request

## Issues

<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

- Resolves #7 

## Description

- `LogLevel.OFF`를 제거합니다.
- `LogLevel`의 모든 목록에 대한 유효성 체크에서 `EnumSet.of` 및 `EnumSet.allOf` 함수를 사용하여 JDK 1.8 호환성을 유지합니다.

## How Has This Been Tested?

- 테스트 생략
