### PR TITLE
캐싱을 위한 `CachedAdaptiveLogger` 클래스를 새롭게 추가하고, 기존 `AdaptiveLogger`의 캐싱을 새 클래스로 위임합니다.

### DIFF
--- a/src/main/java/letsdev/common/log/AdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/AdaptiveLogger.java
@@ -9,20 +9,20 @@ import java.util.Objects;
 public class AdaptiveLogger {
     private final Logger logger;
 
-    protected <T> AdaptiveLogger(Class<T> targetClass) {
+    protected AdaptiveLogger(Class<?> targetClass) {
         this(targetClass.getName());
     }
 
-    protected <T> AdaptiveLogger(String name) {
+    protected AdaptiveLogger(String name) {
         Objects.requireNonNull(name);
         this.logger = LoggerFactory.getLogger(name);
     }
 
-    public static <T> AdaptiveLogger getLogger(Class<T> targetClass) {
+    public static AdaptiveLogger getLogger(Class<?> targetClass) {
         return CachedAdaptiveLogger.getLogger(targetClass.getName());
     }
 
-    public static <T> AdaptiveLogger getLogger(String name) {
+    public static AdaptiveLogger getLogger(String name) {
         return CachedAdaptiveLogger.getLogger(name);
     }
 

--- a/src/main/java/letsdev/common/log/AdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/AdaptiveLogger.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-public final class AdaptiveLogger {
+public class AdaptiveLogger {
     private final Logger logger;
     private final Map<LogLevel, LevelFixedLogger> cachedLoggers = new ConcurrentHashMap<>();
 
-    private <T> AdaptiveLogger(Class<T> targetClass) {
+    protected <T> AdaptiveLogger(Class<T> targetClass) {
         this(targetClass.getName());
     }
 
-    private <T> AdaptiveLogger(String name) {
+    protected <T> AdaptiveLogger(String name) {
         Objects.requireNonNull(name);
         this.logger = LoggerFactory.getLogger(name);
     }

--- a/src/main/java/letsdev/common/log/AdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/AdaptiveLogger.java
@@ -4,13 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class AdaptiveLogger {
     private final Logger logger;
-    private final Map<LogLevel, LevelFixedLogger> cachedLoggers = new ConcurrentHashMap<>();
 
     protected <T> AdaptiveLogger(Class<T> targetClass) {
         this(targetClass.getName());
@@ -27,10 +24,9 @@ public class AdaptiveLogger {
     }
 
     public static <T> AdaptiveLogger getLogger(String name) {
+        // NOTE String::isBlank is since JDK 11
         final String sourceName = isBlank(name) ? "unnamed" : name;
-        return AdaptiveLoggerHolder.ADAPTIVE_LOGGER_MAP.computeIfAbsent(
-                sourceName, (ignore) -> new AdaptiveLogger(sourceName)
-        );
+        return new AdaptiveLogger(sourceName);
     }
 
     private static boolean isBlank(String str) {
@@ -49,18 +45,11 @@ public class AdaptiveLogger {
 
     public LevelFixedLogger with(LogLevel logLevel) {
         Objects.requireNonNull(logLevel);
-        return cachedLoggers.computeIfAbsent(
-                logLevel,
-                (level) -> new LevelFixedLogger(logger, level)
-        );
+        return new LevelFixedLogger(logger, logLevel);
     }
 
     public LevelFixedLogger with(Level logLevel) {
         Objects.requireNonNull(logLevel);
         return with(LogLevel.valueOf(logLevel.name()));
-    }
-
-    private static class AdaptiveLoggerHolder {
-        private static final Map<String, AdaptiveLogger> ADAPTIVE_LOGGER_MAP = new ConcurrentHashMap<>();
     }
 }

--- a/src/main/java/letsdev/common/log/AdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/AdaptiveLogger.java
@@ -19,14 +19,11 @@ public class AdaptiveLogger {
     }
 
     public static <T> AdaptiveLogger getLogger(Class<T> targetClass) {
-        Objects.requireNonNull(targetClass);
-        return getLogger(targetClass.getName());
+        return CachedAdaptiveLogger.getLogger(targetClass.getName());
     }
 
     public static <T> AdaptiveLogger getLogger(String name) {
-        // NOTE String::isBlank is since JDK 11
-        final String sourceName = isBlank(name) ? "unnamed" : name;
-        return new AdaptiveLogger(sourceName);
+        return CachedAdaptiveLogger.getLogger(name);
     }
 
     private static boolean isBlank(String str) {

--- a/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
@@ -28,8 +28,23 @@ public class CachedAdaptiveLogger extends AdaptiveLogger {
 //    }
 
     public static AdaptiveLogger getLogger(String className) {
-        Objects.requireNonNull(className);
+        // NOTE String::isBlank is since JDK 11
+        final String sourceName = isBlank(className) ? "unnamed" : className;
         return Holder.MAP.computeIfAbsent(className, CachedAdaptiveLogger::new);
+    }
+
+    private static boolean isBlank(String str) {
+        if (str == null || str.isEmpty()) {
+            return true;
+        }
+
+        for (char ch: str.toCharArray()) {
+            if (!Character.isWhitespace(ch)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
@@ -1,0 +1,43 @@
+package letsdev.common.log;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CachedAdaptiveLogger extends AdaptiveLogger {
+
+    private final Map<LogLevel, LevelFixedLogger> cache = new ConcurrentHashMap<>();
+
+    private CachedAdaptiveLogger(Class<?> clazz) {
+        super(clazz);
+    }
+
+    private CachedAdaptiveLogger(String className) {
+        super(className);
+    }
+
+    /*
+     * 재밌는 발견:
+     *   'getLogger(Class<?>)' in 'letsdev. common. log. CachedAdaptiveLogger' clashes with 'getLogger(Class<T>)' in 'letsdev. common. log. AdaptiveLogger'; both methods have same erasure, yet neither hides the other
+     *
+     * 이 오류는 수퍼타입의 static 메서드가 오히려 동일한 와일드카드 사용 시 발생하지 않으며, 제네릭 사용 시에만 발견되고 있음.
+     */
+//    public static AdaptiveLogger getLogger(Class<?> clazz) {
+//        Objects.requireNonNull(clazz);
+//        return getLogger(clazz.getName());
+//    }
+
+    public static AdaptiveLogger getLogger(String className) {
+        Objects.requireNonNull(className);
+        return Holder.MAP.computeIfAbsent(className, CachedAdaptiveLogger::new);
+    }
+
+    @Override
+    public LevelFixedLogger with(LogLevel level) {
+        return cache.computeIfAbsent(level, super::with);
+    }
+
+    private static class Holder {
+        private static final Map<String, AdaptiveLogger> MAP = new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
+++ b/src/main/java/letsdev/common/log/CachedAdaptiveLogger.java
@@ -22,10 +22,10 @@ public class CachedAdaptiveLogger extends AdaptiveLogger {
      *
      * 이 오류는 수퍼타입의 static 메서드가 오히려 동일한 와일드카드 사용 시 발생하지 않으며, 제네릭 사용 시에만 발견되고 있음.
      */
-//    public static AdaptiveLogger getLogger(Class<?> clazz) {
-//        Objects.requireNonNull(clazz);
-//        return getLogger(clazz.getName());
-//    }
+    public static AdaptiveLogger getLogger(Class<?> clazz) {
+        Objects.requireNonNull(clazz);
+        return getLogger(clazz.getName());
+    }
 
     public static AdaptiveLogger getLogger(String className) {
         // NOTE String::isBlank is since JDK 11


### PR DESCRIPTION
# Pull Request

## Issues

<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

- Resolves #9 
- Resolves #12 

## Description

- `CachedAdaptiveLogger` 클래스는 캐싱을 위해 새롭게 추가된 클래스입니다.
- `AdaptiveLogger`는 이제 정적 메서드로 `CachedAdaptiveLogger`에 의해 간접적으로만 캐싱을 제공합니다.
- 또한 이 과정에서 정적 메서드 선언에 대해 상위 클래스 및 하위 클래스에서 prototype 불일치에 영향을 받는다는 것을 확인했습니다.  
  단, 이것이 단지 컴파일러에 의해 지적될 뿐, 그것이 어떤 문제가 될 수 있는지 파악이 필요합니다.

## How Has This Been Tested?

- 테스트는 상남자답게 생략합니다.
