### PR TITLE
`LogLevel`은 다시 SLF4J로부터 독립적으로 관리합니다.

### DIFF
--- a/src/main/java/letsdev/common/log/LevelFixedLogger.java
+++ b/src/main/java/letsdev/common/log/LevelFixedLogger.java
@@ -66,7 +66,7 @@ public final class LevelFixedLogger {
     }
 
     public LevelFixedLogger(Logger logger, Level level) {
-        this(logger, LogLevel.valueOf(level));
+        this(logger, Slf4jLevelUtil.toLogLevel(level));
     }
 
     public LogLevel getLogLevel() {

--- a/src/main/java/letsdev/common/log/LogLevel.java
+++ b/src/main/java/letsdev/common/log/LogLevel.java
@@ -1,43 +1,10 @@
 package letsdev.common.log;
 
-import org.slf4j.event.Level;
-
-import java.util.EnumSet;
-
 public enum LogLevel {
-    TRACE(Level.TRACE),
-    DEBUG(Level.DEBUG),
-    INFO(Level.INFO),
-    WARN(Level.WARN),
-    ERROR(Level.ERROR),
-    OFF(null);
-
-    private final Level level;
-
-    LogLevel(Level level) {
-        this.level = level;
-    }
-
-    public static LogLevel valueOf(Level level) {
-        assert EnumSet.of(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR).contains(level);
-
-        switch (level) {
-            case TRACE:
-                return TRACE;
-            case DEBUG:
-                return DEBUG;
-            case INFO:
-                return INFO;
-            case WARN:
-                return WARN;
-            case ERROR:
-                return ERROR;
-            default:
-                return OFF;
-        }
-    }
-
-    public Level toSlf4jLevel() {
-        return level;
-    }
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    OFF
 }

--- a/src/main/java/letsdev/common/log/Slf4jLevelUtil.java
+++ b/src/main/java/letsdev/common/log/Slf4jLevelUtil.java
@@ -1,0 +1,62 @@
+package letsdev.common.log;
+
+import org.slf4j.event.Level;
+
+import java.util.EnumSet;
+
+public final class Slf4jLevelUtil {
+    private Slf4jLevelUtil() {}
+
+    public static LogLevel toLogLevel(Level level) {
+        assert EnumSet.of(
+                Level.TRACE,
+                Level.DEBUG,
+                Level.INFO,
+                Level.WARN,
+                Level.ERROR
+        ).equals(EnumSet.allOf(Level.class)) : "org.slf4j.event.Level 열거상수 목록이 업데이트되었습니다. 점검이 필요합니다.";
+
+        switch (level) {
+            case TRACE:
+                return LogLevel.TRACE;
+            case DEBUG:
+                return LogLevel.DEBUG;
+            case INFO:
+                return LogLevel.INFO;
+            case WARN:
+                return LogLevel.WARN;
+            case ERROR:
+                return LogLevel.ERROR;
+            default:
+                return LogLevel.OFF;
+        }
+    }
+
+    public static Level toSlf4jLevel(LogLevel logLevel) {
+        assert EnumSet.of(
+                LogLevel.TRACE,
+                LogLevel.DEBUG,
+                LogLevel.INFO,
+                LogLevel.WARN,
+                LogLevel.ERROR,
+                LogLevel.OFF
+        ).equals(EnumSet.allOf(LogLevel.class)) : "LogLevel 열거상수 목록이 업데이트되었습니다. 점검이 필요합니다.";
+
+        switch (logLevel) {
+            case TRACE:
+                return Level.TRACE;
+            case DEBUG:
+                return Level.DEBUG;
+            case INFO:
+                return Level.INFO;
+            case WARN:
+                return Level.WARN;
+            case ERROR:
+                return Level.ERROR;
+            case OFF:
+                return null;
+            default:
+                throw new AssertionError("LogLevel 열거상수 목록이 업데이트되었습니다. 점검이 필요합니다.");
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issues

<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

- Resolves #20
- Resolves #21
- Resolves #22 

## Description

- 이제 `LogLevel`은 다시 SLF4J로부터 독립적입니다.
- `Slf4jLevelUtil`을 추가했습니다.
  - `toLogLevel` 정적 함수를 추가했습니다.
  - `toSlf4jLevel` 정적 함수를 추가했습니다.

## How Has This Been Tested?

- 테스트를 생략했습니다.
